### PR TITLE
feat: Generalize and remove wget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.vscode/

--- a/tap_beautifulsoup/client.py
+++ b/tap_beautifulsoup/client.py
@@ -33,7 +33,7 @@ class BeautifulSoupStream(Stream):
 
     def download(self) -> None:
         """Download the HTML file for the stream."""
-        download(self.site_url, self.output_folder, self.logger)
+        download(self.site_url, self.output_folder, logger=self.logger)
 
     def parse_file(self, file: Path) -> str:
         """Parse the HTML file for the stream.

--- a/tap_beautifulsoup/client.py
+++ b/tap_beautifulsoup/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Iterable
+from urllib.parse import urlparse
 
 from bs4 import BeautifulSoup
 from singer_sdk import typing as th  # JSON Schema typing helpers
@@ -47,18 +48,18 @@ class BeautifulSoupStream(Stream):
             data = f.read()
 
         soup = BeautifulSoup(data, features=self.parser)
-        text = soup.find_all(attrs=self.top_attrs)
+        text = soup.find_all(**self.find_all_kwargs)
         if len(text) != 0:
-            text = text[0].get_text()
+            text = "".join([elem.get_text() for elem in text])
         else:
             text = ""
 
         return "\n".join([t for t in text.split("\n") if t])
 
     @property
-    def top_attrs(self) -> dict:
-        """Return the top-level attributes for the stream."""
-        return {"role": "main"}
+    def find_all_kwargs(self) -> dict:
+        """Return the input find_all kwargs."""
+        return self.config["find_all_kwargs"]
 
     def get_records(self, context: dict | None) -> Iterable[dict]:
         """Return a generator of record-type dictionary objects.
@@ -70,16 +71,18 @@ class BeautifulSoupStream(Stream):
         Args:
             context: Stream partition or context dictionary.
         """
-        self.download()
+        if self.config["download_recursively"]:
+            self.download()
 
         docs = []
-        for p in Path(self.output_folder).glob(f"{self.site_url}/**/*.html"):
+        folder_url_base = urlparse(self.site_url).netloc
+        for p in Path(self.output_folder).glob(f"{folder_url_base}/**/*.html"):
             if p.is_dir():
                 continue
 
             text = self.parse_file(p)
             if not text:
-                self.logger.warning(f"Could not find {self.top_attrs} in file {p}.")
+                self.logger.warning(f"Could not find contents in file {p}, using filters {self.find_all_kwargs}.")
 
             record = {
                 "source": str(p),

--- a/tap_beautifulsoup/client.py
+++ b/tap_beautifulsoup/client.py
@@ -33,7 +33,7 @@ class BeautifulSoupStream(Stream):
 
     def download(self) -> None:
         """Download the HTML file for the stream."""
-        download(self.site_url, self.output_folder)
+        download(self.site_url, self.output_folder, self.logger)
 
     def parse_file(self, file: Path) -> str:
         """Parse the HTML file for the stream.

--- a/tap_beautifulsoup/download.py
+++ b/tap_beautifulsoup/download.py
@@ -8,7 +8,7 @@ import requests
 from bs4 import BeautifulSoup
 
 
-def download(url: str, download_folder: Path | str = "output", verbose: bool = False, logger = None):
+def download(url: str, download_folder: Path | str = "output", logger = None):
     if not os.path.exists(download_folder):
         os.makedirs(download_folder)
 

--- a/tap_beautifulsoup/download.py
+++ b/tap_beautifulsoup/download.py
@@ -8,7 +8,7 @@ import requests
 from bs4 import BeautifulSoup
 
 
-def download(url: str, download_folder: Path | str = "output", verbose: bool = False):
+def download(url: str, download_folder: Path | str = "output", verbose: bool = False, logger = None):
     if not os.path.exists(download_folder):
         os.makedirs(download_folder)
 
@@ -27,7 +27,7 @@ def download(url: str, download_folder: Path | str = "output", verbose: bool = F
             response.raise_for_status()
             url = response.url
         except requests.exceptions.RequestException as e:
-            print(f"Failed to fetch {url}: {e}")
+            logger.warn(f"Failed to fetch {url}: {e}")
             return
 
         soup = BeautifulSoup(response.text, "html.parser")

--- a/tap_beautifulsoup/download.py
+++ b/tap_beautifulsoup/download.py
@@ -43,12 +43,17 @@ def download(url: str, download_folder: Path | str = "output", verbose: bool = F
                 _download_recursive(full_url, base_url)
 
         parsed_url = urlparse(url)
-        if parsed_url.path.endswith(".html"):
-            filename = os.path.join(download_folder, base_netloc, parsed_url.path[1:])
-            dirname = os.path.dirname(filename)
+        if parsed_url.path.endswith(".html") or "text/html" in response.headers.get("Content-Type"):
+            file_path = parsed_url.path
+            if file_path.startswith("/"):
+                file_path = file_path[1:]
+            if not file_path or file_path.endswith("/"):
+                file_path = os.path.join(file_path, "index.html")
+            full_file_path = os.path.join(download_folder, base_netloc, file_path)
+            dirname = os.path.dirname(full_file_path)
             if not os.path.exists(dirname):
                 os.makedirs(dirname)
-            with open(filename, "wb") as f:
+            with open(full_file_path, "wb") as f:
                 f.write(response.content)
 
     _download_recursive(url, url)

--- a/tap_beautifulsoup/download.py
+++ b/tap_beautifulsoup/download.py
@@ -19,7 +19,7 @@ def download(url: str, download_folder: Path | str = "output", verbose: bool = F
     visited_urls = set()
     visited_urls.add(parsed_url.path)
 
-    def _download_recursive(url, base_url):
+    def _download_recursive(url, base_url, logger):
         if not url.startswith(base_url):
             return
         try:
@@ -27,7 +27,7 @@ def download(url: str, download_folder: Path | str = "output", verbose: bool = F
             response.raise_for_status()
             url = response.url
         except requests.exceptions.RequestException as e:
-            logger.warn(f"Failed to fetch {url}: {e}")
+            logger.warning(f"Failed to fetch {url}: {e}")
             return
 
         soup = BeautifulSoup(response.text, "html.parser")
@@ -40,7 +40,7 @@ def download(url: str, download_folder: Path | str = "output", verbose: bool = F
 
             if parsed_url.path not in visited_urls and parsed_url.netloc == base_netloc:
                 visited_urls.add(parsed_url.path)
-                _download_recursive(full_url, base_url)
+                _download_recursive(full_url, base_url, logger)
 
         parsed_url = urlparse(url)
         if parsed_url.path.endswith(".html") or "text/html" in response.headers.get("Content-Type"):
@@ -56,4 +56,4 @@ def download(url: str, download_folder: Path | str = "output", verbose: bool = F
             with open(full_file_path, "wb") as f:
                 f.write(response.content)
 
-    _download_recursive(url, url)
+    _download_recursive(url, url, logger)

--- a/tap_beautifulsoup/tap.py
+++ b/tap_beautifulsoup/tap.py
@@ -18,13 +18,12 @@ class TapBeautifulSoup(Tap):
             "source_name",
             th.StringType,
             required=True,
-            default="sdk-docs",
         ),
         th.Property(
             "site_url",
             th.StringType,
             required=True,
-            default="sdk.meltano.com/en/latest/",
+            default="https://sdk.meltano.com/en/latest/",
         ),
         th.Property(
             "output_folder",
@@ -38,6 +37,17 @@ class TapBeautifulSoup(Tap):
             required=True,
             default="html.parser",
             allowed_values=["html.parser"],
+        ),
+        th.Property(
+            "download_recursively",
+            th.BooleanType,
+            default=True,
+            description="Attempt to download all pages recursively into the output directory prior to parsing files. Set this to False if you've previously run `wget -r -A.html https://sdk.meltano.com/en/latest/`",
+        ),
+        th.Property(
+            "find_all_kwargs",
+            th.ObjectType(),
+            description="This dict contains all the kwargs that should be passed to the [`find_all`](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#find-all) call in order to extract text from the pages."
         ),
     ).to_dict()
 


### PR DESCRIPTION
- replaces wget subprocess call with beautiful soup. Closing https://github.com/MeltanoLabs/tap-beautifulsoup/issues/1
- the initial implementation hard coded parsing attributes. I updated it to accept inputs for `find_all` when it attempts to parse each html file it downloaded
- adds a config options to skip the download step `download_recursively`. Some users might want to run wget instead still or the download step already ran but theyre changing the parsing configs. Usually downloading is the most expensive part.