### PR TITLE
fix: Config `KeyError` without `find_all_kwargs`

### DIFF
--- a/tap_beautifulsoup/tap.py
+++ b/tap_beautifulsoup/tap.py
@@ -51,6 +51,7 @@ class TapBeautifulSoup(Tap):
         th.Property(
             "find_all_kwargs",
             th.ObjectType(),
+            default={},
             description="This dict contains all the kwargs that should be passed to the [`find_all`](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#find-all) call in order to extract text from the pages.",
             examples=[{"text": True}, {"attrs": {"role": "main"}}]
         ),

--- a/tap_beautifulsoup/tap.py
+++ b/tap_beautifulsoup/tap.py
@@ -30,14 +30,12 @@ class TapBeautifulSoup(Tap):
         th.Property(
             "output_folder",
             th.StringType,
-            required=True,
             default="output",
             description="The file path of where to write the intermediate downloaded HTML files to.",
         ),
         th.Property(
             "parser",
             th.StringType,
-            required=True,
             default="html.parser",
             allowed_values=["html.parser"],
             description="The BeautifulSoup parser to use.",


### PR DESCRIPTION
Simple fix to default `find_all_kwargs` to an empty dict, since it is not listed as a required setting.

Running with the config

```json
{
    "source_name": "meltano_sdk",
    "site_url": "https://sdk.meltano.com/en/latest/"
}
```

previously did not work

```
  File "/home/reuben/Documents/taps/tap-beautifulsoup/tap_beautifulsoup/client.py", line 51, in parse_file
    text = soup.find_all(**self.find_all_kwargs)
  File "/home/reuben/Documents/taps/tap-beautifulsoup/tap_beautifulsoup/client.py", line 62, in find_all_kwargs
    return self.config["find_all_kwargs"]
KeyError: 'find_all_kwargs'
```

but now does.