### PR TITLE
refactor: Download logic

### DIFF
--- a/tap_beautifulsoup/client.py
+++ b/tap_beautifulsoup/client.py
@@ -31,9 +31,9 @@ class BeautifulSoupStream(Stream):
         """Return the parser for the stream."""
         return self.config["parser"]
 
-    def download(self) -> None:
+    def download(self):
         """Download the HTML file for the stream."""
-        download(self.site_url, self.output_folder, logger=self.logger)
+        yield from download(self.site_url, self.output_folder, logger=self.logger)
 
     def parse_file(self, file: Path) -> str:
         """Parse the HTML file for the stream.
@@ -71,18 +71,21 @@ class BeautifulSoupStream(Stream):
         Args:
             context: Stream partition or context dictionary.
         """
-        if self.config["download_recursively"]:
+
+        folder_url_base = urlparse(self.site_url).netloc
+        html_files = (
             self.download()
+            if self.config["download_recursively"]
+            else (self.output_folder / folder_url_base).rglob("*.html")
+        )
 
         docs = []
-        folder_url_base = urlparse(self.site_url).netloc
-        for p in Path(self.output_folder).glob(f"{folder_url_base}/**/*.html"):
-            if p.is_dir():
-                continue
-
+        for p in html_files:
             text = self.parse_file(p)
             if not text:
-                self.logger.warning(f"Could not find contents in file {p}, using filters {self.find_all_kwargs}.")
+                self.logger.warning(
+                    f"Could not find contents in file {p}, using filters {self.find_all_kwargs}."
+                )
 
             record = {
                 "source": str(p),

--- a/tap_beautifulsoup/client.py
+++ b/tap_beautifulsoup/client.py
@@ -71,8 +71,9 @@ class BeautifulSoupStream(Stream):
         Args:
             context: Stream partition or context dictionary.
         """
+        parsed_url = urlparse(self.site_url)
+        folder_url_base = parsed_url.netloc + parsed_url.path
 
-        folder_url_base = urlparse(self.site_url).netloc
         html_files = (
             self.download()
             if self.config["download_recursively"]

--- a/tap_beautifulsoup/download.py
+++ b/tap_beautifulsoup/download.py
@@ -44,7 +44,7 @@ def download(base_url: str, download_folder: Path, logger=None):
 
         for link in links:
             next_url = urljoin(response.url, link["href"])
-            _download_recursive(next_url, logger)
+            yield from _download_recursive(next_url, logger)
 
         if not path.suffix:
             path = path / "index.html"
@@ -56,4 +56,6 @@ def download(base_url: str, download_folder: Path, logger=None):
         os.makedirs(file_path.parent, exist_ok=True)
         file_path.write_bytes(response.content)
 
-    _download_recursive(base_url, logger)
+        yield file_path
+
+    yield from _download_recursive(base_url, logger)


### PR DESCRIPTION
Refactor of document download logic to fix
- an issue with visited paths when processing output directory structure, having encountered an internal link 404 response
- an issue where all site documents were processed, regardless of whether the site URL contained a path

Also implements yielding of file path from `download` directly, as discussed in #5.